### PR TITLE
feat: add frontend-only pdf editor

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,13 +1,140 @@
-import React from "react";
-import LatexPdfExport from "./LatexPdfExport";
+import React, { useState } from 'react';
+import { AppBar, Toolbar, Typography, Box, Grid, Button, Snackbar, Alert } from '@mui/material';
+import { TitleForm, AuthorForm, AbstractForm, SectionsForm, FiguresForm, ReferenceForm } from './components/form';
 
 function App() {
+  const [title, setTitle] = useState('');
+  const [author, setAuthor] = useState('');
+  const [abstract, setAbstract] = useState('');
+  const [sections, setSections] = useState([{ title: '', text: '' }]);
+  const [figures, setFigures] = useState([]);
+  const [reference, setReference] = useState('');
+  const [pdfUrl, setPdfUrl] = useState('');
+  const [error, setError] = useState('');
+
+  const readFile = (file) =>
+    new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => resolve(reader.result);
+      reader.onerror = reject;
+      reader.readAsDataURL(file);
+    });
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      const { default: jsPDF } = await import('jspdf');
+      const doc = new jsPDF();
+      let y = 20;
+      doc.setFontSize(16);
+      doc.text(title || '', 10, y);
+      y += 10;
+      doc.setFontSize(12);
+      doc.text(author || '', 10, y);
+      y += 10;
+      const abs = doc.splitTextToSize(abstract || '', 180);
+      doc.text(abs, 10, y);
+      y += abs.length * 7 + 5;
+
+      for (const section of sections) {
+        if (y > 270) {
+          doc.addPage();
+          y = 20;
+        }
+        doc.setFontSize(14);
+        doc.text(section.title || '', 10, y);
+        y += 8;
+        doc.setFontSize(12);
+        const split = doc.splitTextToSize(section.text || '', 180);
+        doc.text(split, 10, y);
+        y += split.length * 7 + 5;
+      }
+
+      for (const fig of figures) {
+        if (fig.file) {
+          const dataUrl = await readFile(fig.file);
+          const imgProps = doc.getImageProperties(dataUrl);
+          const pdfWidth = 180;
+          const pdfHeight = (imgProps.height * pdfWidth) / imgProps.width;
+          if (y + pdfHeight > 280) {
+            doc.addPage();
+            y = 20;
+          }
+          doc.addImage(dataUrl, 'PNG', 10, y, pdfWidth, pdfHeight);
+          y += pdfHeight + 5;
+          doc.text(fig.caption || '', 10, y);
+          y += 10;
+        }
+      }
+
+      if (reference) {
+        if (y > 260) {
+          doc.addPage();
+          y = 20;
+        }
+        doc.setFontSize(14);
+        doc.text('References', 10, y);
+        y += 8;
+        doc.setFontSize(12);
+        const refs = doc.splitTextToSize(reference, 180);
+        doc.text(refs, 10, y);
+      }
+
+      const blob = doc.output('blob');
+      setPdfUrl(URL.createObjectURL(blob));
+    } catch (err) {
+      console.error(err);
+      setError('PDF生成に失敗しました');
+    }
+  };
+
   return (
-    <div>
-      <h1>LaTeX PDF 出力デモ</h1>
-      <LatexPdfExport />
-    </div>
+    <Box>
+      <AppBar position="sticky">
+        <Toolbar>
+          <Typography variant="h6" sx={{ flexGrow: 1 }}>
+            バーチャル学会向け 要旨作成フォーム
+          </Typography>
+        </Toolbar>
+      </AppBar>
+
+      <Grid container spacing={2} sx={{ p: 2 }}>
+        <Grid item xs={12} md={6}>
+          <Box component="form" onSubmit={handleSubmit}>
+            <TitleForm title={title} onChangeTitle={setTitle} />
+            <AuthorForm author={author} onChangeAuthor={setAuthor} />
+            <AbstractForm abstract={abstract} onChangeAbstract={setAbstract} />
+            <SectionsForm sections={sections} onChangeSections={setSections} />
+            <FiguresForm figures={figures} onChangeFigures={setFigures} />
+            <ReferenceForm reference={reference} onChangeReference={setReference} />
+            <Button type="submit" variant="contained" fullWidth>
+              pdf出力
+            </Button>
+          </Box>
+        </Grid>
+        <Grid item xs={12} md={6}>
+          <Typography variant="h6">pdf出力結果</Typography>
+          <Box mt={1} sx={{ border: '1px solid #ccc', minHeight: 800 }}>
+            {pdfUrl ? (
+              <iframe title="pdf" src={pdfUrl} style={{ width: '100%', height: '100%' }} />
+            ) : (
+              <Typography color="text.secondary">出力結果がありません</Typography>
+            )}
+          </Box>
+        </Grid>
+      </Grid>
+      <Snackbar
+        open={Boolean(error)}
+        autoHideDuration={6000}
+        onClose={() => setError('')}
+      >
+        <Alert severity="error" onClose={() => setError('')}>
+          {error}
+        </Alert>
+      </Snackbar>
+    </Box>
   );
 }
 
 export default App;
+

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,9 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders pdf output button', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const button = screen.getByRole('button', { name: /pdf出力/i });
+  expect(button).toBeInTheDocument();
 });
+

--- a/src/components/form.js
+++ b/src/components/form.js
@@ -1,0 +1,81 @@
+import React from 'react';
+import { Box, Button, TextField, Typography } from '@mui/material';
+
+export const TitleForm = ({ title, onChangeTitle }) => (
+  <Box mb={2}>
+    <TextField label="タイトル" fullWidth value={title} onChange={(e)=>onChangeTitle(e.target.value)} />
+  </Box>
+);
+
+export const AuthorForm = ({ author, onChangeAuthor }) => (
+  <Box mb={2}>
+    <TextField label="著者" fullWidth value={author} onChange={(e)=>onChangeAuthor(e.target.value)} />
+  </Box>
+);
+
+export const AbstractForm = ({ abstract, onChangeAbstract }) => (
+  <Box mb={2}>
+    <TextField label="概要" multiline minRows={3} fullWidth value={abstract} onChange={(e)=>onChangeAbstract(e.target.value)} />
+  </Box>
+);
+
+export const SectionsForm = ({ sections, onChangeSections }) => {
+  const handleChange = (idx, field, value) => {
+    const next = sections.map((s, i) => i === idx ? { ...s, [field]: value } : s);
+    onChangeSections(next);
+  };
+  const add = () => onChangeSections([...sections, { title: '', text: '' }]);
+  const remove = (idx) => {
+    const next = sections.filter((_, i) => i !== idx);
+    onChangeSections(next);
+  };
+  return (
+    <Box mb={2}>
+      <Typography variant="h6">本文セクション</Typography>
+      {sections.map((section, idx) => (
+        <Box key={idx} mb={2}>
+          <TextField label={`セクション${idx + 1} タイトル`} fullWidth value={section.title} onChange={(e)=>handleChange(idx,'title',e.target.value)} sx={{ mb: 1 }} />
+          <TextField label="本文" multiline minRows={3} fullWidth value={section.text} onChange={(e)=>handleChange(idx,'text',e.target.value)} />
+          <Button onClick={()=>remove(idx)} sx={{ mt: 1 }}>削除</Button>
+        </Box>
+      ))}
+      <Button onClick={add}>セクション追加</Button>
+    </Box>
+  );
+};
+
+export const FiguresForm = ({ figures, onChangeFigures }) => {
+  const handleChange = (idx, field, value) => {
+    const next = figures.map((f, i) => i === idx ? { ...f, [field]: value } : f);
+    onChangeFigures(next);
+  };
+  const add = () => onChangeFigures([...figures, { caption: '', file: undefined }]);
+  const remove = (idx) => {
+    const next = figures.filter((_, i) => i !== idx);
+    onChangeFigures(next);
+  };
+  return (
+    <Box mb={2}>
+      <Typography variant="h6">図</Typography>
+      {figures.map((fig, idx) => (
+        <Box key={idx} mb={2}>
+          <TextField label={`図${idx + 1} キャプション`} fullWidth value={fig.caption} onChange={(e)=>handleChange(idx,'caption',e.target.value)} sx={{ mb: 1 }} />
+          <Button variant="outlined" component="label">
+            画像を選択
+            <input type="file" hidden onChange={(e)=>handleChange(idx,'file',e.target.files?.[0])} />
+          </Button>
+          {fig.file && <Typography variant="body2" sx={{ mt: 1 }}>{fig.file.name}</Typography>}
+          <Button onClick={()=>remove(idx)} sx={{ mt: 1 }}>削除</Button>
+        </Box>
+      ))}
+      <Button onClick={add}>図を追加</Button>
+    </Box>
+  );
+};
+
+export const ReferenceForm = ({ reference, onChangeReference }) => (
+  <Box mb={2}>
+    <TextField label="参考文献" multiline minRows={3} fullWidth value={reference} onChange={(e)=>onChangeReference(e.target.value)} />
+  </Box>
+);
+


### PR DESCRIPTION
## Summary
- build multi-section LaTeX-style editor forms
- generate and preview PDFs purely in the browser
- test basic rendering

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_688e1d4435e88323b54e3c28e11d4f5d